### PR TITLE
refactor: migrate test infrastructure to rstest framework

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "rstest",
         "serde"
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,8 +86,10 @@ dependencies = [
  "atty",
  "clap",
  "dirs",
+ "rstest",
  "serde",
  "serde_json",
+ "strip-ansi-escapes",
  "toml",
 ]
 
@@ -168,6 +179,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +231,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -256,6 +316,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,10 +366,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -329,6 +489,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -377,11 +552,17 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.0",
  "toml_parser",
  "toml_writer",
  "winnow",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -390,6 +571,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "winnow",
 ]
 
 [[package]]
@@ -418,6 +610,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wasi"
@@ -532,3 +733,6 @@ name = "winnow"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ dirs = "6.0.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 toml = "0.9.5"
+
+[dev-dependencies]
+rstest = "0.26.1"
+strip-ansi-escapes = "0.2.1"

--- a/docs/todo-refactoring-phase1.md
+++ b/docs/todo-refactoring-phase1.md
@@ -68,7 +68,7 @@ pub trait Module {
 
 ### 3. フォーマット文字列パーサーの実装
 
-status: Todo
+status: Done
 
 **なぜ**: 現在は固定されたモジュール順序。設定ファイルの`format`フィールドが使われていない
 
@@ -86,7 +86,7 @@ pub fn parse_format(format: &str, context: &Context) -> Vec<String> {
 
 ### 4. エラーハンドリングの改善
 
-status: Todo
+status: Decline
 
 **なぜ**: 現在は単純にエラーメッセージを出力するだけ
 
@@ -111,7 +111,7 @@ match parse_claude_input(&buffer) {
 
 ### 5. Configのモジュール設定分離
 
-status: Todo
+status: Decline
 
 **なぜ**: 現在はConfig構造体に全モジュールの設定が直接定義されている
 
@@ -133,7 +133,7 @@ impl ModuleConfig for DirectoryConfig {}
 
 ### 6. テストヘルパーの追加
 
-status: Todo
+status: Done
 
 **なぜ**: 現在のテストは繰り返しが多く、設定しづらい
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+// Export public modules for testing
+pub mod config;
+pub mod modules;
+pub mod parser;
+pub mod types;
+
+// Re-export commonly used items
+pub use config::Config;
+pub use parser::parse_claude_input;
+pub use types::context::Context;

--- a/tests/common/builders.rs
+++ b/tests/common/builders.rs
@@ -1,0 +1,137 @@
+use beacon::config::Config;
+use beacon::types::claude::{ClaudeInput, ModelInfo, OutputStyle, WorkspaceInfo};
+use beacon::types::context::Context;
+
+/// Builder for creating test ClaudeInput instances
+pub struct ClaudeInputBuilder {
+    hook_event_name: Option<String>,
+    session_id: String,
+    transcript_path: Option<String>,
+    cwd: String,
+    model: ModelInfo,
+    workspace: Option<WorkspaceInfo>,
+    version: Option<String>,
+    output_style: Option<OutputStyle>,
+}
+
+impl ClaudeInputBuilder {
+    pub fn new() -> Self {
+        Self {
+            hook_event_name: None,
+            session_id: "test-session".to_string(),
+            transcript_path: None,
+            cwd: "/test/dir".to_string(),
+            model: ModelInfo {
+                id: "claude-opus".to_string(),
+                display_name: "Opus".to_string(),
+            },
+            workspace: Some(WorkspaceInfo {
+                current_dir: "/test/dir".to_string(),
+                project_dir: Some("/test".to_string()),
+            }),
+            version: Some("1.0.0".to_string()),
+            output_style: None,
+        }
+    }
+
+    pub fn with_cwd(mut self, cwd: &str) -> Self {
+        self.cwd = cwd.to_string();
+        if let Some(ref mut workspace) = self.workspace {
+            workspace.current_dir = cwd.to_string();
+        }
+        self
+    }
+
+    pub fn with_model(mut self, display_name: &str) -> Self {
+        self.model.display_name = display_name.to_string();
+        self.model.id = format!("claude-{}", display_name.to_lowercase());
+        self
+    }
+
+    pub fn with_model_id(mut self, id: &str, display_name: &str) -> Self {
+        self.model.id = id.to_string();
+        self.model.display_name = display_name.to_string();
+        self
+    }
+
+    pub fn with_session_id(mut self, session_id: &str) -> Self {
+        self.session_id = session_id.to_string();
+        self
+    }
+
+    pub fn with_workspace(mut self, current_dir: &str, project_dir: &str) -> Self {
+        self.workspace = Some(WorkspaceInfo {
+            current_dir: current_dir.to_string(),
+            project_dir: Some(project_dir.to_string()),
+        });
+        self
+    }
+
+    pub fn without_workspace(mut self) -> Self {
+        self.workspace = None;
+        self
+    }
+
+    pub fn build(self) -> ClaudeInput {
+        ClaudeInput {
+            hook_event_name: self.hook_event_name,
+            session_id: self.session_id,
+            transcript_path: self.transcript_path,
+            cwd: self.cwd,
+            model: self.model,
+            workspace: self.workspace,
+            version: self.version,
+            output_style: self.output_style,
+        }
+    }
+}
+
+/// Builder for creating test Context instances
+pub struct ContextBuilder {
+    input: ClaudeInputBuilder,
+    config: Config,
+}
+
+impl ContextBuilder {
+    pub fn new() -> Self {
+        Self {
+            input: ClaudeInputBuilder::new(),
+            config: Config::default(),
+        }
+    }
+
+    pub fn with_cwd(mut self, cwd: &str) -> Self {
+        self.input = self.input.with_cwd(cwd);
+        self
+    }
+
+    pub fn with_model(mut self, display_name: &str) -> Self {
+        self.input = self.input.with_model(display_name);
+        self
+    }
+
+    pub fn with_config(mut self, config: Config) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn with_directory_config<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut beacon::types::config::DirectoryConfig),
+    {
+        f(&mut self.config.directory);
+        self
+    }
+
+    pub fn with_claude_model_config<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut beacon::types::config::ClaudeModelConfig),
+    {
+        f(&mut self.config.claude_model);
+        self
+    }
+
+    pub fn build(self) -> Context {
+        Context::new(self.input.build(), self.config)
+    }
+}

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -1,0 +1,108 @@
+use rstest::*;
+use beacon::config::Config;
+use beacon::types::claude::ClaudeInput;
+use beacon::types::context::Context;
+use crate::common::builders::{ClaudeInputBuilder, ContextBuilder};
+
+/// Default test configuration fixture
+#[fixture]
+pub fn default_config() -> Config {
+    Config::default()
+}
+
+/// Default ClaudeInput fixture
+#[fixture]
+pub fn default_claude_input() -> ClaudeInput {
+    ClaudeInputBuilder::new().build()
+}
+
+/// Default Context fixture
+#[fixture]
+pub fn default_context() -> Context {
+    ContextBuilder::new().build()
+}
+
+/// Test paths fixture - provides common test paths
+#[fixture]
+pub fn test_paths() -> TestPaths {
+    TestPaths {
+        home: "/Users/test".to_string(),
+        project: "/Users/test/projects/beacon".to_string(),
+        deep_nested: "/Users/test/very/deep/nested/directory/structure/project".to_string(),
+    }
+}
+
+pub struct TestPaths {
+    pub home: String,
+    pub project: String,
+    pub deep_nested: String,
+}
+
+/// TestRenderer for module testing - Starship-inspired pattern
+pub struct TestRenderer {
+    context: Context,
+}
+
+impl TestRenderer {
+    pub fn new() -> Self {
+        Self {
+            context: ContextBuilder::new().build(),
+        }
+    }
+
+    pub fn with_context(mut self, context: Context) -> Self {
+        self.context = context;
+        self
+    }
+
+    pub fn with_cwd(mut self, cwd: &str) -> Self {
+        let new_input = ClaudeInputBuilder::new().with_cwd(cwd).build();
+        self.context = Context::new(new_input, self.context.config.clone());
+        self
+    }
+
+    pub fn with_model(mut self, display_name: &str) -> Self {
+        let current_dir = self.context.current_dir.to_string_lossy().to_string();
+        let new_input = ClaudeInputBuilder::new()
+            .with_cwd(&current_dir)
+            .with_model(display_name)
+            .build();
+        self.context = Context::new(new_input, self.context.config.clone());
+        self
+    }
+
+    pub fn context(&self) -> &Context {
+        &self.context
+    }
+
+    /// Render a module and return its output
+    pub fn render<M: beacon::modules::Module>(&self, module: &M) -> String {
+        // For testing, we use EmptyConfig as default
+        module.render(&self.context, &beacon::modules::EmptyConfig)
+    }
+}
+
+/// Fixture for TestRenderer
+#[fixture]
+pub fn test_renderer() -> TestRenderer {
+    TestRenderer::new()
+}
+
+/// Parameterized fixture for different model types
+#[fixture]
+#[once]
+pub fn model_names() -> Vec<&'static str> {
+    vec!["Opus", "Sonnet", "Haiku", "Claude-3.5"]
+}
+
+/// Parameterized fixture for different directory paths  
+#[fixture]
+#[once]
+pub fn test_directories() -> Vec<&'static str> {
+    vec![
+        "/home/user/project",
+        "/Users/test/Documents/code",
+        "/var/www/html",
+        "C:\\Users\\test\\project",
+    ]
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,12 @@
+// Test fixtures and helpers using rstest
+pub mod fixtures;
+pub mod builders;
+
+pub use builders::{ClaudeInputBuilder, ContextBuilder};
+pub use fixtures::{
+    default_context,
+    default_claude_input,
+    default_config,
+    test_paths,
+    TestRenderer,
+};


### PR DESCRIPTION
## Summary

This PR migrates the test infrastructure from a custom test helper system to the modern rstest framework, following Rust's official testing best practices.

## Motivation

The existing test helpers in `src/test_helpers.rs` didn't follow Rust community conventions. This migration:
- Adopts the official `tests/common/mod.rs` pattern for test utilities
- Leverages rstest for more maintainable and concise tests
- Reduces test code duplication by ~30%

## Changes

### 🔄 Test Infrastructure Migration
- **Before**: Custom test helpers in `src/test_helpers.rs`
- **After**: Organized test utilities in `tests/common/` following Rust best practices
  - `tests/common/mod.rs` - Module exports
  - `tests/common/builders.rs` - Builder patterns for test data
  - `tests/common/fixtures.rs` - rstest fixtures and test renderer

### 📦 New Dependencies
- `rstest` (v0.26.1) - Fixture-based test framework
- `strip-ansi-escapes` (v0.2.1) - For testing ANSI-formatted output

### ♻️ Test Refactoring
Converted all existing tests to use rstest's parametric testing:

```rust
// Before: Multiple similar test functions
#[test]
fn test_home() { /* ... */ }
#[test]
fn test_subdir() { /* ... */ }

// After: Single parametric test
#[rstest]
#[case("/Users/test", "~")]
#[case("/Users/test/projects", "~/projects")]
fn test_home_abbreviation(#[case] cwd: &str, #[case] expected: &str) {
    // Single test implementation for multiple cases
}
```

### 📚 Library Support
- Created `src/lib.rs` to expose public modules for testing
- Added Default trait implementations for module structs (clippy compliance)

## Benefits

✅ **Code Reduction**: ~30% less test code through parametric testing
✅ **Best Practices**: Follows Rust's official test organization guidelines
✅ **Maintainability**: Clearer separation between unit and integration tests
✅ **Modern Framework**: Leverages rstest's powerful fixture and parametric testing features

## Test Coverage

All 38 existing tests pass successfully:
- Unit tests for modules (directory, claude_model)
- Context creation and manipulation tests
- Parser and configuration tests

## References

- [Rust Book: Test Organization](https://doc.rust-lang.org/book/ch11-03-test-organization.html)
- [rstest Documentation](https://github.com/la10736/rstest)

## Checklist

- [x] All tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy warnings resolved (`cargo clippy`)
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed core library modules with convenient re-exports for easier integration.
  * Added default constructors to key modules for simpler instantiation.

* **Documentation**
  * Added guidance on improving test efficiency and ROI, with before/after examples.
  * Updated refactoring phase status notes.

* **Tests**
  * Introduced parameterized tests, fixtures, and builders to expand coverage and readability across models, paths, and context scenarios.

* **Chores**
  * Added development dependencies and updated editor spelling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->