### PR TITLE
fix(claude_model): make default symbol empty

### DIFF
--- a/crates/beacon-core/src/config.rs
+++ b/crates/beacon-core/src/config.rs
@@ -131,7 +131,7 @@ mod tests {
         // Test claude_model module defaults
         assert_eq!(config.claude_model.format, "[$symbol$model]($style)");
         assert_eq!(config.claude_model.style, "bold yellow");
-        assert_eq!(config.claude_model.symbol, "<");
+        assert_eq!(config.claude_model.symbol, "");
         assert!(!config.claude_model.disabled);
     }
 
@@ -200,7 +200,7 @@ mod tests {
         assert_eq!(config.format, "$directory $claude_model");
         assert_eq!(config.command_timeout, 500);
         assert_eq!(config.directory.format, "[$path]($style)");
-        assert_eq!(config.claude_model.symbol, "<");
+        assert_eq!(config.claude_model.symbol, "");
     }
 
     #[test]
@@ -244,5 +244,12 @@ mod tests {
                 .list_extra_modules()
                 .contains(&"my_custom".to_string())
         );
+    }
+
+    #[test]
+    fn test_claude_model_default_symbol_is_empty() {
+        // New desired default behavior for issue #27
+        let cfg = Config::default();
+        assert_eq!(cfg.claude_model.symbol, "");
     }
 }

--- a/crates/beacon-core/src/types/config.rs
+++ b/crates/beacon-core/src/types/config.rs
@@ -278,7 +278,7 @@ fn default_claude_model_style() -> String {
 }
 
 fn default_claude_model_symbol() -> String {
-    "<".to_string()
+    "".to_string()
 }
 
 // Git Branch module defaults


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Claude model symbol to be empty, removing the leading “<” from outputs by default. Existing setups that relied on the previous default may now show outputs without a prefix unless a custom symbol is configured.
* **Tests**
  * Updated tests to reflect the new default and added coverage to ensure the symbol defaults to empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->