### PR TITLE
Add context window usage percentage display module

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ _**[Learn more about Claude Code status line integration](https://docs.anthropic
 - `git_branch`
 - `git_status`
 - `claude_model`
+- `context_window`
 
 ### Default Style
 
 ```toml
-Format = "$directory $git_branch $git_status $claude_model"
+Format = "$directory $git_branch $git_status $claude_model $context_window"
 
 [directory]
 style = "bold cyan"
@@ -102,6 +103,13 @@ style = "bold red"
 
 [claude_model]
 style = "bold yellow"
+
+[context_window]
+symbol = "ctx "
+use_dynamic_color = true
+style_low = "green"           # < 50%
+style_medium = "yellow"       # 50-79%
+style_high = "red"            # ≥ 80%
 ```
 
 ### Presets Styles

--- a/crates/claude-code-statusline-core/src/engine.rs
+++ b/crates/claude-code-statusline-core/src/engine.rs
@@ -101,6 +101,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let cfg = Config::default();
         let engine = Engine::new(cfg);

--- a/crates/claude-code-statusline-core/src/modules/claude_model.rs
+++ b/crates/claude-code-statusline-core/src/modules/claude_model.rs
@@ -129,6 +129,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }

--- a/crates/claude-code-statusline-core/src/modules/claude_model.rs
+++ b/crates/claude-code-statusline-core/src/modules/claude_model.rs
@@ -112,7 +112,16 @@ mod tests {
     use crate::types::context::Context;
     use rstest::*;
 
-    /// Helper to create context with specific model
+    /// Creates a test `Context` populated with a `ClaudeInput` that uses the provided model display name.
+    ///
+    /// The returned `Context` contains fixed test values for session, paths, workspace, version, and output fields. The embedded `ModelInfo` will have `id` set to `claude-{lowercased model_name}` and `display_name` set to `model_name`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let ctx = context_with_model("Sonnet 4");
+    /// assert!(ctx.model_display_name().contains("Sonnet 4"));
+    /// ```
     fn context_with_model(model_name: &str) -> Context {
         let input = ClaudeInput {
             hook_event_name: None,
@@ -129,6 +138,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -1,0 +1,227 @@
+//! Context window usage module for displaying token consumption percentage
+//!
+//! This module shows the current context window usage as a percentage,
+//! with color coding based on usage levels.
+
+use super::{Module, ModuleConfig};
+use crate::types::context::Context;
+
+/// Module that displays context window usage percentage
+///
+/// Renders the context window usage with automatic color coding:
+/// - Green: < 50% usage
+/// - Yellow: 50-79% usage
+/// - Red: ≥ 80% usage
+///
+/// # Configuration
+///
+/// ```toml
+/// [context_window]
+/// format = "[$symbol$percentage%]($style)"
+/// symbol = "ctx "
+/// disabled = false
+/// ```
+///
+/// # Calculation
+///
+/// Percentage = (input_tokens + cache_creation_input_tokens + cache_read_input_tokens) * 100 / context_window_size
+pub struct ContextWindowModule;
+
+impl ContextWindowModule {
+    /// Create a new ContextWindowModule instance
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Create from Context (kept for compatibility)
+    pub fn from_context(_context: &Context) -> Self {
+        Self::new()
+    }
+
+    /// Calculate the usage percentage from context window data
+    fn calculate_percentage(context: &Context) -> Option<u64> {
+        let ctx_window = context.input.context_window.as_ref()?;
+
+        // Use total_input_tokens directly from Claude Code
+        let total_tokens = ctx_window.total_input_tokens;
+
+        if ctx_window.context_window_size == 0 {
+            return None;
+        }
+
+        Some((total_tokens * 100) / ctx_window.context_window_size)
+    }
+
+    /// Get the color style based on percentage
+    fn get_color_for_percentage(percentage: u64) -> &'static str {
+        if percentage < 50 {
+            "green"
+        } else if percentage < 80 {
+            "yellow"
+        } else {
+            "red"
+        }
+    }
+}
+
+impl Default for ContextWindowModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Module for ContextWindowModule {
+    fn name(&self) -> &str {
+        "context_window"
+    }
+
+    fn should_display(&self, context: &Context, config: &dyn ModuleConfig) -> bool {
+        // Check if the module is disabled in config
+        if let Some(cfg) = config
+            .as_any()
+            .downcast_ref::<crate::types::config::ContextWindowConfig>()
+        {
+            if cfg.disabled {
+                return false;
+            }
+        }
+
+        // Only display if context_window data is present
+        Self::calculate_percentage(context).is_some()
+    }
+
+    fn render(&self, context: &Context, config: &dyn ModuleConfig) -> String {
+        let percentage = match Self::calculate_percentage(context) {
+            Some(p) => p,
+            None => return String::new(),
+        };
+
+        if let Some(cfg) = config
+            .as_any()
+            .downcast_ref::<crate::types::config::ContextWindowConfig>()
+        {
+            use std::collections::HashMap;
+            let mut tokens = HashMap::new();
+            tokens.insert("percentage", percentage.to_string());
+            tokens.insert("symbol", cfg.symbol.clone());
+
+            // Determine color based on percentage
+            let color = Self::get_color_for_percentage(percentage);
+            let style = if cfg.use_dynamic_color {
+                color.to_string()
+            } else {
+                cfg.style.clone()
+            };
+
+            return crate::style::render_with_style_template(cfg.format(), &tokens, &style);
+        }
+
+        // Fallback rendering
+        format!("[ctx {}%]", percentage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::types::claude::{ClaudeInput, ContextWindow, CurrentUsage, ModelInfo};
+    use crate::types::context::Context;
+    use rstest::*;
+
+    /// Helper to create context with specific context window data
+    fn context_with_usage(total_input: u64, total_output: u64, window_size: u64) -> Context {
+        let input = ClaudeInput {
+            hook_event_name: None,
+            session_id: "test-session".to_string(),
+            transcript_path: None,
+            cwd: "/test/dir".to_string(),
+            model: ModelInfo {
+                id: "claude-opus".to_string(),
+                display_name: "Opus".to_string(),
+            },
+            workspace: None,
+            version: Some("1.0.0".to_string()),
+            output_style: None,
+            context_window: Some(ContextWindow {
+                total_input_tokens: total_input,
+                total_output_tokens: total_output,
+                context_window_size: window_size,
+                current_usage: None,
+            }),
+        };
+        Context::new(input, Config::default())
+    }
+
+    #[rstest]
+    #[case(25000, 0, 200000, 12)] // 12.5% rounds down to 12%
+    #[case(50000, 0, 200000, 25)] // 25%
+    #[case(100000, 0, 200000, 50)] // 50%
+    #[case(150000, 0, 200000, 75)] // 75%
+    #[case(160000, 0, 200000, 80)] // 80%
+    fn test_percentage_calculation(
+        #[case] input: u64,
+        #[case] output: u64,
+        #[case] size: u64,
+        #[case] expected: u64,
+    ) {
+        let context = context_with_usage(input, output, size);
+        let percentage = ContextWindowModule::calculate_percentage(&context);
+        assert_eq!(percentage, Some(expected));
+    }
+
+    #[rstest]
+    #[case(30, "green")]
+    #[case(49, "green")]
+    #[case(50, "yellow")]
+    #[case(79, "yellow")]
+    #[case(80, "red")]
+    #[case(95, "red")]
+    fn test_color_for_percentage(#[case] percentage: u64, #[case] expected_color: &str) {
+        let color = ContextWindowModule::get_color_for_percentage(percentage);
+        assert_eq!(color, expected_color);
+    }
+
+    #[rstest]
+    fn test_should_display_with_context_window() {
+        let module = ContextWindowModule::new();
+        let context = context_with_usage(50000, 0, 200000);
+        assert!(module.should_display(&context, &context.config.context_window));
+    }
+
+    #[rstest]
+    fn test_should_not_display_without_context_window() {
+        let module = ContextWindowModule::new();
+        let input = ClaudeInput {
+            hook_event_name: None,
+            session_id: "test-session".to_string(),
+            transcript_path: None,
+            cwd: "/test/dir".to_string(),
+            model: ModelInfo {
+                id: "claude-opus".to_string(),
+                display_name: "Opus".to_string(),
+            },
+            workspace: None,
+            version: Some("1.0.0".to_string()),
+            output_style: None,
+            context_window: None,
+        };
+        let context = Context::new(input, Config::default());
+        assert!(!module.should_display(&context, &context.config.context_window));
+    }
+
+    #[rstest]
+    fn test_module_metadata() {
+        let module = ContextWindowModule::new();
+        assert_eq!(module.name(), "context_window");
+    }
+
+    #[rstest]
+    fn test_render_contains_percentage() {
+        let module = ContextWindowModule::new();
+        let context = context_with_usage(50000, 0, 200000);
+        let rendered = module.render(&context, &context.config.context_window);
+        let plain = String::from_utf8(strip_ansi_escapes::strip(rendered)).unwrap();
+        assert!(plain.contains("25"));
+    }
+}

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -313,6 +313,24 @@ mod tests {
     }
 
     #[rstest]
+    #[case(30, "green")]   // Below custom threshold_medium (60)
+    #[case(59, "green")]   // Just below threshold_medium
+    #[case(60, "yellow")]  // At threshold_medium
+    #[case(89, "yellow")]  // Just below threshold_high
+    #[case(90, "red")]     // At threshold_high
+    #[case(95, "red")]     // Above threshold_high
+    fn test_custom_threshold_values(#[case] percentage: u64, #[case] expected_style: &str) {
+        use crate::types::config::ContextWindowConfig;
+        let mut config = ContextWindowConfig::default();
+        // Set custom thresholds: 60% for medium, 90% for high
+        config.threshold_medium = 60;
+        config.threshold_high = 90;
+
+        let style = ContextWindowModule::get_style_for_percentage(percentage, &config);
+        assert_eq!(style, expected_style);
+    }
+
+    #[rstest]
     fn test_should_display_with_context_window() {
         let module = ContextWindowModule::new();
         let context = context_with_usage(50000, 0, 200000);

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -1,0 +1,355 @@
+//! Context window usage module for displaying token consumption percentage
+//!
+//! This module shows the current context window usage as a percentage,
+//! with color coding based on usage levels.
+
+use super::{Module, ModuleConfig};
+use crate::types::context::Context;
+
+/// Module that displays context window usage percentage
+///
+/// Renders the context window usage with automatic color coding:
+/// - Green: < 50% usage
+/// - Yellow: 50-79% usage
+/// - Red: ≥ 80% usage
+///
+/// # Configuration
+///
+/// ```toml
+/// [context_window]
+/// format = "[$symbol$percentage%]($style)"
+/// symbol = "ctx "
+/// disabled = false
+/// ```
+///
+/// # Calculation
+///
+/// Percentage = (input_tokens + cache_creation_input_tokens + cache_read_input_tokens) * 100 / context_window_size
+pub struct ContextWindowModule;
+
+impl ContextWindowModule {
+    /// Create a new ContextWindowModule instance
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Creates a new ContextWindowModule while preserving the older API that accepted a `Context`.
+    ///
+    /// The supplied `context` parameter is unused and kept only for compatibility with call sites that
+    /// previously constructed the module from a `Context`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let ctx = crate::types::context::Context::default();
+    /// let m1 = crate::modules::context_window::ContextWindowModule::new();
+    /// let m2 = crate::modules::context_window::ContextWindowModule::from_context(&ctx);
+    /// // Both constructors produce equivalent module instances (no internal state).
+    /// ```
+    pub fn from_context(_context: &Context) -> Self {
+        Self::new()
+    }
+
+    /// Computes the context window usage as a percentage of the configured window size.
+    ///
+    /// When available, the calculation uses the breakdown in `current_usage` (sum of `input_tokens`,
+    /// `cache_creation_input_tokens`, and `cache_read_input_tokens`); otherwise it falls back to
+    /// `total_input_tokens`. Returns `None` when `context_window_size` is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Given a context whose context window contains 25 used tokens and a window size of 100:
+    /// // `calculate_percentage(&context)` returns `Some(25)`.
+    /// let pct = calculate_percentage(&context);
+    /// assert_eq!(pct, Some(25));
+    /// ```
+    fn calculate_percentage(context: &Context) -> Option<u64> {
+        let ctx_window = context.input.context_window.as_ref()?;
+
+        // Prefer current_usage breakdown if available (includes cached tokens)
+        let total_tokens = if let Some(usage) = &ctx_window.current_usage {
+            usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
+        } else {
+            // Fallback to total_input_tokens if current_usage not available
+            ctx_window.total_input_tokens
+        };
+
+        if ctx_window.context_window_size == 0 {
+            return None;
+        }
+
+        Some((total_tokens * 100) / ctx_window.context_window_size)
+    }
+
+    /// Selects a style string from the config based on a usage percentage.
+    ///
+    /// Uses these thresholds:
+    /// - Less than 50 -> `style_low`
+    /// - 50 through 79 -> `style_medium`
+    /// - 80 or greater -> `style_high`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = crate::types::config::ContextWindowConfig::default();
+    /// assert_eq!(get_style_for_percentage(10, &cfg), cfg.style_low);
+    /// assert_eq!(get_style_for_percentage(50, &cfg), cfg.style_medium);
+    /// assert_eq!(get_style_for_percentage(95, &cfg), cfg.style_high);
+    /// ```
+    fn get_style_for_percentage(percentage: u64, config: &crate::types::config::ContextWindowConfig) -> String {
+        if percentage < 50 {
+            config.style_low.clone()
+        } else if percentage < 80 {
+            config.style_medium.clone()
+        } else {
+            config.style_high.clone()
+        }
+    }
+}
+
+impl Default for ContextWindowModule {
+    /// Constructs a new ContextWindowModule with default settings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let module = ContextWindowModule::default();
+    /// let _module2 = ContextWindowModule::new();
+    /// ```
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Module for ContextWindowModule {
+    /// Module identifier for the context window module.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let module = crate::modules::context_window::ContextWindowModule::new();
+    /// assert_eq!(module.name(), "context_window");
+    /// ```
+    ///
+    /// # Returns
+    ///
+    /// `"context_window"` — the module's identifier string.
+    fn name(&self) -> &str {
+        "context_window"
+    }
+
+    /// Determine whether the module should be shown for the given context and configuration.
+    ///
+    /// Returns `true` if the context contains context window data and the `ContextWindowConfig` is not disabled, `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::modules::context_window::ContextWindowModule;
+    /// use crate::types::config::ContextWindowConfig;
+    /// use crate::types::context::Context;
+    ///
+    /// let module = ContextWindowModule::new();
+    /// let ctx = Context::default();
+    /// let cfg = ContextWindowConfig::default();
+    /// // With a default context that has no context_window data this returns false.
+    /// assert!(!module.should_display(&ctx, &cfg));
+    /// ```
+    fn should_display(&self, context: &Context, config: &dyn ModuleConfig) -> bool {
+        // Check if the module is disabled in config
+        if let Some(cfg) = config
+            .as_any()
+            .downcast_ref::<crate::types::config::ContextWindowConfig>()
+        {
+            if cfg.disabled {
+                return false;
+            }
+        }
+
+        // Only display if context_window data is present
+        Self::calculate_percentage(context).is_some()
+    }
+
+    /// Renders the context window usage as a styled percentage string.
+    ///
+    /// If the context contains a context window and a percentage can be calculated, this returns
+    /// the configured formatted string with tokens `percentage` and `symbol`, using dynamic color
+    /// tiers when enabled. If the context has no usable context window data, an empty string is
+    /// returned. If the provided `config` cannot be downcast to `ContextWindowConfig`, a simple
+    /// fallback string in the form `"[ctx {percentage}%]"` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Illustrative example; types like `Context` and `ContextWindowConfig` are assumed to be in scope.
+    /// let module = ContextWindowModule::new();
+    /// // When context lacks context_window data, the module returns an empty string.
+    /// let empty = module.render(&Context::default(), &SomeOtherConfig {});
+    /// assert_eq!(empty, "");
+    ///
+    /// // When a context and config are provided and downcasting succeeds, the output contains the percentage.
+    /// // let output = module.render(&populated_context, &context_window_config);
+    /// // assert!(output.contains("25")); // e.g., "25" appears in the rendered string
+    /// ```
+    fn render(&self, context: &Context, config: &dyn ModuleConfig) -> String {
+        let percentage = match Self::calculate_percentage(context) {
+            Some(p) => p,
+            None => return String::new(),
+        };
+
+        if let Some(cfg) = config
+            .as_any()
+            .downcast_ref::<crate::types::config::ContextWindowConfig>()
+        {
+            use std::collections::HashMap;
+            let mut tokens = HashMap::new();
+            tokens.insert("percentage", percentage.to_string());
+            tokens.insert("symbol", cfg.symbol.clone());
+
+            // Determine style based on percentage
+            let style = if cfg.use_dynamic_color {
+                Self::get_style_for_percentage(percentage, cfg)
+            } else {
+                cfg.style.clone()
+            };
+
+            return crate::style::render_with_style_template(cfg.format(), &tokens, &style);
+        }
+
+        // Fallback rendering
+        format!("[ctx {}%]", percentage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::types::claude::{ClaudeInput, ContextWindow, ModelInfo};
+    use crate::types::context::Context;
+    use rstest::*;
+
+    /// Creates a test `Context` containing a `ContextWindow` with the specified
+    /// total input tokens, total output tokens, and context window size.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let ctx = context_with_usage(100, 50, 400);
+    /// assert_eq!(ctx.input.context_window.unwrap().total_input_tokens, 100);
+    /// assert_eq!(ctx.input.context_window.unwrap().total_output_tokens, 50);
+    /// assert_eq!(ctx.input.context_window.unwrap().context_window_size, 400);
+    /// ```
+    fn context_with_usage(total_input: u64, total_output: u64, window_size: u64) -> Context {
+        let input = ClaudeInput {
+            hook_event_name: None,
+            session_id: "test-session".to_string(),
+            transcript_path: None,
+            cwd: "/test/dir".to_string(),
+            model: ModelInfo {
+                id: "claude-opus".to_string(),
+                display_name: "Opus".to_string(),
+            },
+            workspace: None,
+            version: Some("1.0.0".to_string()),
+            output_style: None,
+            context_window: Some(ContextWindow {
+                total_input_tokens: total_input,
+                total_output_tokens: total_output,
+                context_window_size: window_size,
+                current_usage: None,
+            }),
+        };
+        Context::new(input, Config::default())
+    }
+
+    #[rstest]
+    #[case(25000, 0, 200000, 12)] // 12.5% rounds down to 12%
+    #[case(50000, 0, 200000, 25)] // 25%
+    #[case(100000, 0, 200000, 50)] // 50%
+    #[case(150000, 0, 200000, 75)] // 75%
+    #[case(160000, 0, 200000, 80)] // 80%
+    fn test_percentage_calculation(
+        #[case] input: u64,
+        #[case] output: u64,
+        #[case] size: u64,
+        #[case] expected: u64,
+    ) {
+        let context = context_with_usage(input, output, size);
+        let percentage = ContextWindowModule::calculate_percentage(&context);
+        assert_eq!(percentage, Some(expected));
+    }
+
+    #[rstest]
+    #[case(30, "green")]
+    #[case(49, "green")]
+    #[case(50, "yellow")]
+    #[case(79, "yellow")]
+    #[case(80, "red")]
+    #[case(95, "red")]
+    fn test_style_for_percentage(#[case] percentage: u64, #[case] expected_style: &str) {
+        use crate::types::config::ContextWindowConfig;
+        let config = ContextWindowConfig::default();
+        let style = ContextWindowModule::get_style_for_percentage(percentage, &config);
+        assert_eq!(style, expected_style);
+    }
+
+    #[rstest]
+    #[case(30, "bold green")]
+    #[case(50, "bold yellow")]
+    #[case(80, "bold red")]
+    fn test_custom_threshold_styles(#[case] percentage: u64, #[case] expected_style: &str) {
+        use crate::types::config::ContextWindowConfig;
+        let mut config = ContextWindowConfig::default();
+        config.style_low = "bold green".to_string();
+        config.style_medium = "bold yellow".to_string();
+        config.style_high = "bold red".to_string();
+
+        let style = ContextWindowModule::get_style_for_percentage(percentage, &config);
+        assert_eq!(style, expected_style);
+    }
+
+    #[rstest]
+    fn test_should_display_with_context_window() {
+        let module = ContextWindowModule::new();
+        let context = context_with_usage(50000, 0, 200000);
+        assert!(module.should_display(&context, &context.config.context_window));
+    }
+
+    #[rstest]
+    fn test_should_not_display_without_context_window() {
+        let module = ContextWindowModule::new();
+        let input = ClaudeInput {
+            hook_event_name: None,
+            session_id: "test-session".to_string(),
+            transcript_path: None,
+            cwd: "/test/dir".to_string(),
+            model: ModelInfo {
+                id: "claude-opus".to_string(),
+                display_name: "Opus".to_string(),
+            },
+            workspace: None,
+            version: Some("1.0.0".to_string()),
+            output_style: None,
+            context_window: None,
+        };
+        let context = Context::new(input, Config::default());
+        assert!(!module.should_display(&context, &context.config.context_window));
+    }
+
+    #[rstest]
+    fn test_module_metadata() {
+        let module = ContextWindowModule::new();
+        assert_eq!(module.name(), "context_window");
+    }
+
+    #[rstest]
+    fn test_render_contains_percentage() {
+        let module = ContextWindowModule::new();
+        let context = context_with_usage(50000, 0, 200000);
+        let rendered = module.render(&context, &context.config.context_window);
+        let plain = String::from_utf8(strip_ansi_escapes::strip(rendered)).unwrap();
+        assert!(plain.contains("25"));
+    }
+}

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -69,7 +69,9 @@ impl ContextWindowModule {
 
         // Prefer current_usage breakdown if available (includes cached tokens)
         let total_tokens = if let Some(usage) = &ctx_window.current_usage {
-            usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
+            usage.input_tokens
+                .saturating_add(usage.cache_creation_input_tokens)
+                .saturating_add(usage.cache_read_input_tokens)
         } else {
             // Fallback to total_input_tokens if current_usage not available
             ctx_window.total_input_tokens

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -40,7 +40,7 @@ impl ContextWindowModule {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let ctx = crate::types::context::Context::default();
     /// let m1 = crate::modules::context_window::ContextWindowModule::new();
     /// let m2 = crate::modules::context_window::ContextWindowModule::from_context(&ctx);
@@ -58,7 +58,7 @@ impl ContextWindowModule {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// // Given a context whose context window contains 25 used tokens and a window size of 100:
     /// // `calculate_percentage(&context)` returns `Some(25)`.
     /// let pct = calculate_percentage(&context);
@@ -86,23 +86,23 @@ impl ContextWindowModule {
 
     /// Selects a style string from the config based on a usage percentage.
     ///
-    /// Uses these thresholds:
-    /// - Less than 50 -> `style_low`
-    /// - 50 through 79 -> `style_medium`
-    /// - 80 or greater -> `style_high`
+    /// Uses configurable thresholds from the config:
+    /// - Less than `threshold_medium` -> `style_low`
+    /// - `threshold_medium` through `threshold_high - 1` -> `style_medium`
+    /// - `threshold_high` or greater -> `style_high`
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let cfg = crate::types::config::ContextWindowConfig::default();
     /// assert_eq!(get_style_for_percentage(10, &cfg), cfg.style_low);
     /// assert_eq!(get_style_for_percentage(50, &cfg), cfg.style_medium);
     /// assert_eq!(get_style_for_percentage(95, &cfg), cfg.style_high);
     /// ```
     fn get_style_for_percentage(percentage: u64, config: &crate::types::config::ContextWindowConfig) -> String {
-        if percentage < 50 {
+        if percentage < config.threshold_medium {
             config.style_low.clone()
-        } else if percentage < 80 {
+        } else if percentage < config.threshold_high {
             config.style_medium.clone()
         } else {
             config.style_high.clone()
@@ -129,7 +129,7 @@ impl Module for ContextWindowModule {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let module = crate::modules::context_window::ContextWindowModule::new();
     /// assert_eq!(module.name(), "context_window");
     /// ```
@@ -147,7 +147,7 @@ impl Module for ContextWindowModule {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use crate::modules::context_window::ContextWindowModule;
     /// use crate::types::config::ContextWindowConfig;
     /// use crate::types::context::Context;
@@ -183,7 +183,7 @@ impl Module for ContextWindowModule {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// // Illustrative example; types like `Context` and `ContextWindowConfig` are assumed to be in scope.
     /// let module = ContextWindowModule::new();
     /// // When context lacks context_window data, the module returns an empty string.

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -79,7 +79,9 @@ impl ContextWindowModule {
             return None;
         }
 
-        Some((total_tokens * 100) / ctx_window.context_window_size)
+        total_tokens
+            .checked_mul(100)?
+            .checked_div(ctx_window.context_window_size)
     }
 
     /// Selects a style string from the config based on a usage percentage.

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -42,8 +42,13 @@ impl ContextWindowModule {
     fn calculate_percentage(context: &Context) -> Option<u64> {
         let ctx_window = context.input.context_window.as_ref()?;
 
-        // Use total_input_tokens directly from Claude Code
-        let total_tokens = ctx_window.total_input_tokens;
+        // Prefer current_usage breakdown if available (includes cached tokens)
+        let total_tokens = if let Some(usage) = &ctx_window.current_usage {
+            usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens
+        } else {
+            // Fallback to total_input_tokens if current_usage not available
+            ctx_window.total_input_tokens
+        };
 
         if ctx_window.context_window_size == 0 {
             return None;
@@ -52,14 +57,14 @@ impl ContextWindowModule {
         Some((total_tokens * 100) / ctx_window.context_window_size)
     }
 
-    /// Get the color style based on percentage
-    fn get_color_for_percentage(percentage: u64) -> &'static str {
+    /// Get the style based on percentage and config
+    fn get_style_for_percentage(percentage: u64, config: &crate::types::config::ContextWindowConfig) -> String {
         if percentage < 50 {
-            "green"
+            config.style_low.clone()
         } else if percentage < 80 {
-            "yellow"
+            config.style_medium.clone()
         } else {
-            "red"
+            config.style_high.clone()
         }
     }
 }
@@ -105,10 +110,9 @@ impl Module for ContextWindowModule {
             tokens.insert("percentage", percentage.to_string());
             tokens.insert("symbol", cfg.symbol.clone());
 
-            // Determine color based on percentage
-            let color = Self::get_color_for_percentage(percentage);
+            // Determine style based on percentage
             let style = if cfg.use_dynamic_color {
-                color.to_string()
+                Self::get_style_for_percentage(percentage, cfg)
             } else {
                 cfg.style.clone()
             };
@@ -125,7 +129,7 @@ impl Module for ContextWindowModule {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::types::claude::{ClaudeInput, ContextWindow, CurrentUsage, ModelInfo};
+    use crate::types::claude::{ClaudeInput, ContextWindow, ModelInfo};
     use crate::types::context::Context;
     use rstest::*;
 
@@ -177,9 +181,26 @@ mod tests {
     #[case(79, "yellow")]
     #[case(80, "red")]
     #[case(95, "red")]
-    fn test_color_for_percentage(#[case] percentage: u64, #[case] expected_color: &str) {
-        let color = ContextWindowModule::get_color_for_percentage(percentage);
-        assert_eq!(color, expected_color);
+    fn test_style_for_percentage(#[case] percentage: u64, #[case] expected_style: &str) {
+        use crate::types::config::ContextWindowConfig;
+        let config = ContextWindowConfig::default();
+        let style = ContextWindowModule::get_style_for_percentage(percentage, &config);
+        assert_eq!(style, expected_style);
+    }
+
+    #[rstest]
+    #[case(30, "bold green")]
+    #[case(50, "bold yellow")]
+    #[case(80, "bold red")]
+    fn test_custom_threshold_styles(#[case] percentage: u64, #[case] expected_style: &str) {
+        use crate::types::config::ContextWindowConfig;
+        let mut config = ContextWindowConfig::default();
+        config.style_low = "bold green".to_string();
+        config.style_medium = "bold yellow".to_string();
+        config.style_high = "bold red".to_string();
+
+        let style = ContextWindowModule::get_style_for_percentage(percentage, &config);
+        assert_eq!(style, expected_style);
     }
 
     #[rstest]

--- a/crates/claude-code-statusline-core/src/modules/context_window.rs
+++ b/crates/claude-code-statusline-core/src/modules/context_window.rs
@@ -115,7 +115,7 @@ impl Default for ContextWindowModule {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let module = ContextWindowModule::default();
     /// let _module2 = ContextWindowModule::new();
     /// ```

--- a/crates/claude-code-statusline-core/src/modules/directory.rs
+++ b/crates/claude-code-statusline-core/src/modules/directory.rs
@@ -208,6 +208,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }
@@ -229,6 +230,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }
@@ -327,6 +329,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -364,6 +367,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -404,6 +408,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -444,6 +449,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -482,6 +488,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -521,6 +528,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;

--- a/crates/claude-code-statusline-core/src/modules/directory.rs
+++ b/crates/claude-code-statusline-core/src/modules/directory.rs
@@ -208,11 +208,22 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }
 
-    /// Helper to create context with specific cwd
+    /// Create a test Context whose current working directory and workspace are set to `cwd`.
+    ///
+    /// This helper constructs a ClaudeInput populated with `cwd` and default test values, then
+    /// wraps it in a default Config to produce a Context suitable for unit tests.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let ctx = context_with_cwd("/tmp/project");
+    /// // use `ctx` in tests, e.g. pass to module renderers
+    /// ```
     fn context_with_cwd(cwd: &str) -> Context {
         let input = ClaudeInput {
             hook_event_name: None,
@@ -229,6 +240,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }
@@ -304,6 +316,19 @@ mod tests {
         repo
     }
 
+    /// Verifies that rendering from a repository root, with truncation to the repository enabled,
+    /// produces only the repository name.
+    ///
+    /// Sets the directory truncation mode to use the repository as the root and a truncation
+    /// length that preserves only the repository name, then asserts the rendered (ANSI-stripped)
+    /// output equals the repository directory name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Creates a temporary git repo, configures truncation to repo, and asserts rendering:
+    /// // `plain == repo_name`
+    /// ```
     #[cfg(feature = "git")]
     #[rstest]
     fn repo_root_displays_repo_name_only() {
@@ -327,6 +352,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -364,6 +390,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -404,6 +431,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -444,6 +472,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -458,6 +487,15 @@ mod tests {
         assert_eq!(plain, format!("{}/…/{}", repo_name, "d"));
     }
 
+    /// Verifies that when truncation_length exactly equals the repository name plus the tail segments, the truncation symbol is not inserted into the rendered path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // With a repository at `root` and current directory `root/src/module`,
+    /// // setting `truncation_length = 3` (repo + 2 segments) should render:
+    /// // "repoName/src/module" — no truncation symbol should appear.
+    /// ```
     #[cfg(feature = "git")]
     #[rstest]
     fn no_symbol_when_not_truncated_in_repo() {
@@ -482,6 +520,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;
@@ -521,6 +560,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let mut cfg = crate::config::Config::default();
         cfg.directory.truncate_to_repo = true;

--- a/crates/claude-code-statusline-core/src/modules/git_branch.rs
+++ b/crates/claude-code-statusline-core/src/modules/git_branch.rs
@@ -189,6 +189,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }

--- a/crates/claude-code-statusline-core/src/modules/git_branch.rs
+++ b/crates/claude-code-statusline-core/src/modules/git_branch.rs
@@ -173,6 +173,17 @@ mod tests {
     use tempfile::tempdir;
 
     // Helper: ClaudeInput -> Context 生成
+    /// Creates a test Context populated with a ClaudeInput whose working directory and workspace
+    /// point to the given `cwd`.
+    ///
+    /// The returned Context uses default configuration values suitable for unit tests.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let ctx = make_context("/tmp/project");
+    /// // `ctx` can now be passed to module methods in tests
+    /// ```
     fn make_context(cwd: &str) -> Context {
         let input = ClaudeInput {
             hook_event_name: None,
@@ -189,6 +200,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }

--- a/crates/claude-code-statusline-core/src/modules/git_status.rs
+++ b/crates/claude-code-statusline-core/src/modules/git_status.rs
@@ -222,6 +222,18 @@ mod tests {
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
 
+    /// Create a test `Context` populated with a minimal `ClaudeInput` using the given working directory.
+    ///
+    /// The returned `Context` is constructed with default configuration and fields appropriate for unit tests:
+    /// session id "test-session", the provided `cwd` as workspace/current dir, a default model, and other optional
+    /// fields left unset.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let ctx = make_context("/tmp/repo");
+    /// let _ = ctx; // use `ctx` in tests
+    /// ```
     fn make_context(cwd: &str) -> Context {
         let input = ClaudeInput {
             hook_event_name: None,
@@ -238,6 +250,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }

--- a/crates/claude-code-statusline-core/src/modules/git_status.rs
+++ b/crates/claude-code-statusline-core/src/modules/git_status.rs
@@ -238,6 +238,7 @@ mod tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         Context::new(input, Config::default())
     }

--- a/crates/claude-code-statusline-core/src/modules/mod.rs
+++ b/crates/claude-code-statusline-core/src/modules/mod.rs
@@ -15,6 +15,7 @@
 //!
 //! - `directory`: Current directory display
 //! - `claude_model`: Claude model information
+//! - `context_window`: Context window usage percentage
 //! - `git_branch`: Current git branch
 //! - `git_status`: Git repository status
 
@@ -83,6 +84,7 @@ pub trait Module: Send + Sync {
 
 // Re-export module implementations
 pub mod claude_model;
+pub mod context_window;
 pub mod directory;
 #[cfg(feature = "git")]
 pub mod git_branch;
@@ -91,6 +93,7 @@ pub mod git_status;
 pub mod registry;
 
 pub use claude_model::ClaudeModelModule;
+pub use context_window::ContextWindowModule;
 pub use directory::DirectoryModule;
 pub use registry::{ModuleFactory, Registry};
 
@@ -238,6 +241,21 @@ mod timeout_tests {
         }
     }
 
+    /// Creates a test Context with the given current working directory and command timeout.
+    ///
+    /// The returned Context is constructed from a minimal ClaudeInput suitable for tests:
+    /// - `session_id` is "test-session"
+    /// - `model` is set to `claude-opus` / "Opus"
+    /// - `workspace.current_dir` and `workspace.project_dir` are set to `cwd`
+    /// - `context_window` is `None`
+    /// The Config used sets `command_timeout` to `timeout_ms`; other fields use defaults.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let ctx = make_context("/tmp/myproj", 50);
+    /// assert_eq!(ctx.config.command_timeout, 50);
+    /// ```
     fn make_context(cwd: &str, timeout_ms: u64) -> Context {
         let input = ClaudeInput {
             hook_event_name: None,
@@ -254,6 +272,7 @@ mod timeout_tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let cfg = Config {
             command_timeout: timeout_ms,

--- a/crates/claude-code-statusline-core/src/modules/mod.rs
+++ b/crates/claude-code-statusline-core/src/modules/mod.rs
@@ -15,6 +15,7 @@
 //!
 //! - `directory`: Current directory display
 //! - `claude_model`: Claude model information
+//! - `context_window`: Context window usage percentage
 //! - `git_branch`: Current git branch
 //! - `git_status`: Git repository status
 
@@ -83,6 +84,7 @@ pub trait Module: Send + Sync {
 
 // Re-export module implementations
 pub mod claude_model;
+pub mod context_window;
 pub mod directory;
 #[cfg(feature = "git")]
 pub mod git_branch;
@@ -91,6 +93,7 @@ pub mod git_status;
 pub mod registry;
 
 pub use claude_model::ClaudeModelModule;
+pub use context_window::ContextWindowModule;
 pub use directory::DirectoryModule;
 pub use registry::{ModuleFactory, Registry};
 
@@ -254,6 +257,7 @@ mod timeout_tests {
             }),
             version: Some("1.0.0".into()),
             output_style: None,
+            context_window: None,
         };
         let cfg = Config {
             command_timeout: timeout_ms,

--- a/crates/claude-code-statusline-core/src/modules/registry.rs
+++ b/crates/claude-code-statusline-core/src/modules/registry.rs
@@ -44,7 +44,7 @@ impl Registry {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let reg = Registry::with_defaults();
     /// let names = reg.list();
     /// assert!(names.contains(&"directory"));
@@ -125,7 +125,7 @@ impl ModuleFactory for ClaudeModelFactory {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// // given a `context` value populated from the application's configuration:
     /// let cfg_opt = ClaudeModelFactory.config(&context);
     /// assert!(cfg_opt.is_some());
@@ -145,7 +145,7 @@ impl ModuleFactory for ContextWindowFactory {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let f = ContextWindowFactory;
     /// assert_eq!(f.name(), "context_window");
     /// ```
@@ -156,7 +156,7 @@ impl ModuleFactory for ContextWindowFactory {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// let factory = ContextWindowFactory;
     /// let ctx = /* construct or obtain a `Context` */ unimplemented!();
     /// let module = factory.create(&ctx);
@@ -177,7 +177,7 @@ impl ModuleFactory for ContextWindowFactory {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let factory = ContextWindowFactory;
     /// let ctx = Context::default();
     /// let cfg = factory.config(&ctx);

--- a/crates/claude-code-statusline-core/src/modules/registry.rs
+++ b/crates/claude-code-statusline-core/src/modules/registry.rs
@@ -4,7 +4,10 @@
 //! without hard-coded dispatcher matches. This enables pluggable modules
 //! and paves the way for external/extra modules via configuration.
 
-use super::{Module, ModuleConfig, claude_model::ClaudeModelModule, directory::DirectoryModule};
+use super::{
+    claude_model::ClaudeModelModule, context_window::ContextWindowModule,
+    directory::DirectoryModule, Module, ModuleConfig,
+};
 #[cfg(feature = "git")]
 use super::{git_branch::GitBranchModule, git_status::GitStatusModule};
 use crate::types::context::Context;
@@ -34,11 +37,25 @@ impl Registry {
         }
     }
 
-    /// Default registry with built-in modules
+    /// Creates a Registry pre-populated with the built-in module factories.
+    ///
+    /// The returned registry includes the core module factories. If the `git` feature is
+    /// enabled at compile time, the corresponding Git-related factories are included as well.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let reg = Registry::with_defaults();
+    /// let names = reg.list();
+    /// assert!(names.contains(&"directory"));
+    /// assert!(names.contains(&"claude_model"));
+    /// assert!(names.contains(&"context_window"));
+    /// ```
     pub fn with_defaults() -> Self {
         let mut reg = Self::new();
         reg.register_factory(DirectoryFactory);
         reg.register_factory(ClaudeModelFactory);
+        reg.register_factory(ContextWindowFactory);
         #[cfg(feature = "git")]
         {
             reg.register_factory(GitBranchFactory);
@@ -104,8 +121,70 @@ impl ModuleFactory for ClaudeModelFactory {
     fn create(&self, context: &Context) -> Box<dyn Module> {
         Box::new(ClaudeModelModule::from_context(context))
     }
+    /// Accesses the Claude model configuration stored in the provided context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // given a `context` value populated from the application's configuration:
+    /// let cfg_opt = ClaudeModelFactory.config(&context);
+    /// assert!(cfg_opt.is_some());
+    /// ```
     fn config<'a>(&self, context: &'a Context) -> Option<&'a dyn ModuleConfig> {
         Some(&context.config.claude_model)
+    }
+}
+
+struct ContextWindowFactory;
+impl ModuleFactory for ContextWindowFactory {
+    /// Canonical module name for the ContextWindowFactory.
+    ///
+    /// # Returns
+    ///
+    /// The string `"context_window"`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let f = ContextWindowFactory;
+    /// assert_eq!(f.name(), "context_window");
+    /// ```
+    fn name(&self) -> &'static str {
+        "context_window"
+    }
+    /// Creates a new ContextWindow module instance configured from the provided Context.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let factory = ContextWindowFactory;
+    /// let ctx = /* construct or obtain a `Context` */ unimplemented!();
+    /// let module = factory.create(&ctx);
+    /// assert_eq!(module.name(), "context_window");
+    /// ```
+    fn create(&self, context: &Context) -> Box<dyn Module> {
+        Box::new(ContextWindowModule::from_context(context))
+    }
+    /// Get the Context Window module's config view from the given Context.
+    ///
+    /// # Parameters
+    ///
+    /// - `context`: The execution context containing application configuration.
+    ///
+    /// # Returns
+    ///
+    /// `Some` containing the Context Window module's config view from `context`, or `None` if not available.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let factory = ContextWindowFactory;
+    /// let ctx = Context::default();
+    /// let cfg = factory.config(&ctx);
+    /// assert!(cfg.is_some());
+    /// ```
+    fn config<'a>(&self, context: &'a Context) -> Option<&'a dyn ModuleConfig> {
+        Some(&context.config.context_window)
     }
 }
 
@@ -152,6 +231,7 @@ mod tests {
         let names = reg.list();
         assert!(names.contains(&"directory"));
         assert!(names.contains(&"claude_model"));
+        assert!(names.contains(&"context_window"));
         #[cfg(feature = "git")]
         {
             assert!(names.contains(&"git_branch"));
@@ -174,6 +254,7 @@ mod tests {
             workspace: None,
             version: None,
             output_style: None,
+            context_window: None,
         };
         let ctx = Context::new(input, cfg);
         let reg = Registry::with_defaults();

--- a/crates/claude-code-statusline-core/src/modules/registry.rs
+++ b/crates/claude-code-statusline-core/src/modules/registry.rs
@@ -4,7 +4,10 @@
 //! without hard-coded dispatcher matches. This enables pluggable modules
 //! and paves the way for external/extra modules via configuration.
 
-use super::{Module, ModuleConfig, claude_model::ClaudeModelModule, directory::DirectoryModule};
+use super::{
+    claude_model::ClaudeModelModule, context_window::ContextWindowModule,
+    directory::DirectoryModule, Module, ModuleConfig,
+};
 #[cfg(feature = "git")]
 use super::{git_branch::GitBranchModule, git_status::GitStatusModule};
 use crate::types::context::Context;
@@ -39,6 +42,7 @@ impl Registry {
         let mut reg = Self::new();
         reg.register_factory(DirectoryFactory);
         reg.register_factory(ClaudeModelFactory);
+        reg.register_factory(ContextWindowFactory);
         #[cfg(feature = "git")]
         {
             reg.register_factory(GitBranchFactory);
@@ -109,6 +113,19 @@ impl ModuleFactory for ClaudeModelFactory {
     }
 }
 
+struct ContextWindowFactory;
+impl ModuleFactory for ContextWindowFactory {
+    fn name(&self) -> &'static str {
+        "context_window"
+    }
+    fn create(&self, context: &Context) -> Box<dyn Module> {
+        Box::new(ContextWindowModule::from_context(context))
+    }
+    fn config<'a>(&self, context: &'a Context) -> Option<&'a dyn ModuleConfig> {
+        Some(&context.config.context_window)
+    }
+}
+
 #[cfg(feature = "git")]
 struct GitBranchFactory;
 #[cfg(feature = "git")]
@@ -152,6 +169,7 @@ mod tests {
         let names = reg.list();
         assert!(names.contains(&"directory"));
         assert!(names.contains(&"claude_model"));
+        assert!(names.contains(&"context_window"));
         #[cfg(feature = "git")]
         {
             assert!(names.contains(&"git_branch"));
@@ -174,6 +192,7 @@ mod tests {
             workspace: None,
             version: None,
             output_style: None,
+            context_window: None,
         };
         let ctx = Context::new(input, cfg);
         let reg = Registry::with_defaults();

--- a/crates/claude-code-statusline-core/src/parser.rs
+++ b/crates/claude-code-statusline-core/src/parser.rs
@@ -236,6 +236,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
 
         let config = Config::default();
@@ -266,6 +267,7 @@ mod tests {
             workspace: None,
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
 
         let config = Config::default();
@@ -295,6 +297,7 @@ mod tests {
             workspace: None,
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         };
 
         let config = Config::default();

--- a/crates/claude-code-statusline-core/src/types/claude.rs
+++ b/crates/claude-code-statusline-core/src/types/claude.rs
@@ -44,6 +44,8 @@ pub struct ClaudeInput {
     pub version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_style: Option<OutputStyle>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<ContextWindow>,
 }
 
 /// Information about the current Claude model
@@ -77,4 +79,34 @@ pub struct WorkspaceInfo {
 pub struct OutputStyle {
     /// Name of the output style
     pub name: String,
+}
+
+/// Context window usage information
+///
+/// Contains information about token usage and context window size.
+/// Matches the structure sent by Claude Code.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ContextWindow {
+    /// Total input tokens used
+    pub total_input_tokens: u64,
+    /// Total output tokens generated
+    pub total_output_tokens: u64,
+    /// Total context window size
+    pub context_window_size: u64,
+    /// Detailed current usage breakdown (may be null)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_usage: Option<CurrentUsage>,
+}
+
+/// Breakdown of current token usage (when available)
+///
+/// Tracks different types of tokens being used in the current context.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CurrentUsage {
+    /// Regular input tokens
+    pub input_tokens: u64,
+    /// Tokens used for cache creation
+    pub cache_creation_input_tokens: u64,
+    /// Tokens read from cache
+    pub cache_read_input_tokens: u64,
 }

--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -183,7 +183,7 @@ impl Default for GitBranchConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct GitStatusSymbolsConfig {
     #[serde(default = "default_git_status_symbol_conflicted")]
     pub conflicted: String,
@@ -251,7 +251,6 @@ impl Default for GitStatusConfig {
     /// let cfg = GitStatusConfig::default();
     /// assert_eq!(cfg.format, default_git_status_format());
     /// assert_eq!(cfg.style, default_git_status_style());
-    /// assert_eq!(cfg.symbols, GitStatusSymbolsConfig::default());
     /// assert_eq!(cfg.disabled, default_disabled());
     /// ```
     fn default() -> Self {
@@ -706,27 +705,16 @@ impl ModuleConfig for ContextWindowConfig {
 
 impl Config {
     /// Validate configuration fields and ensure values fall within allowed ranges.
-    
     ///
-    
     /// Currently this enforces that the `command_timeout` value is between 50 and 600_000
-    
     /// milliseconds (inclusive). If a value is outside this range, the function returns
-    
     /// `CoreError::InvalidConfig` describing the invalid value.
-    
     ///
-    
     /// # Examples
-
     ///
-
     /// ```ignore
-
     /// let cfg = Config::default();
-
     /// cfg.validate().unwrap();
-
     /// ```
     pub fn validate(&self) -> Result<(), CoreError> {
         // Milliseconds; enforce sane bounds (50ms ..= 600_000ms)
@@ -927,5 +915,17 @@ mod validation_tests {
         assert!(ws.iter().any(|w| w.contains("bg:#12AB")));
         assert!(ws.iter().any(|w| w.contains("fg:300")));
         assert!(ws.iter().any(|w| w.contains("sparkle")));
+    }
+
+    #[test]
+    fn context_window_style_validation() {
+        let mut cfg = Config::default();
+        cfg.context_window.style = "bold green".to_string();
+        let ws = cfg.collect_warnings();
+        assert!(ws.is_empty(), "valid style should produce no warnings");
+
+        cfg.context_window.style = "fg:invalid-color".to_string();
+        let ws = cfg.collect_warnings();
+        assert!(ws.iter().any(|w| w.contains("context_window")));
     }
 }

--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -54,6 +54,9 @@ pub struct Config {
     #[serde(default)]
     pub git_status: GitStatusConfig,
 
+    #[serde(default)]
+    pub context_window: ContextWindowConfig,
+
     /// Unrecognized/extra top-level tables (e.g., third-party modules)
     /// Captures unknown sections like `[my_custom_module]` without losing them.
     #[serde(flatten)]
@@ -114,6 +117,7 @@ impl Default for Config {
             claude_model: ClaudeModelConfig::default(),
             git_branch: GitBranchConfig::default(),
             git_status: GitStatusConfig::default(),
+            context_window: ContextWindowConfig::default(),
             extra_modules: toml::value::Table::new(),
         }
     }
@@ -239,6 +243,40 @@ impl Default for GitStatusConfig {
     }
 }
 
+/// Configuration for the context window module
+///
+/// Controls how the context window usage percentage is displayed.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ContextWindowConfig {
+    #[serde(default = "default_context_window_format")]
+    pub format: String,
+
+    #[serde(default = "default_context_window_style")]
+    pub style: String,
+
+    #[serde(default = "default_context_window_symbol")]
+    pub symbol: String,
+
+    /// Use dynamic color based on percentage (green/yellow/red)
+    #[serde(default = "default_context_window_use_dynamic_color")]
+    pub use_dynamic_color: bool,
+
+    #[serde(default = "default_disabled")]
+    pub disabled: bool,
+}
+
+impl Default for ContextWindowConfig {
+    fn default() -> Self {
+        ContextWindowConfig {
+            format: default_context_window_format(),
+            style: default_context_window_style(),
+            symbol: default_context_window_symbol(),
+            use_dynamic_color: default_context_window_use_dynamic_color(),
+            disabled: default_disabled(),
+        }
+    }
+}
+
 // Default value functions
 fn default_format() -> String {
     "$directory $claude_model".to_string()
@@ -347,6 +385,23 @@ fn default_git_status_symbol_diverged() -> String {
     "⇕".to_string()
 }
 
+// Context Window module defaults
+fn default_context_window_format() -> String {
+    "[$symbol$percentage%]($style)".to_string()
+}
+
+fn default_context_window_style() -> String {
+    "bold".to_string()
+}
+
+fn default_context_window_symbol() -> String {
+    "ctx ".to_string()
+}
+
+fn default_context_window_use_dynamic_color() -> bool {
+    true
+}
+
 // ModuleConfig implementations
 impl ModuleConfig for DirectoryConfig {
     fn as_any(&self) -> &dyn Any {
@@ -391,6 +446,20 @@ impl ModuleConfig for GitBranchConfig {
 }
 
 impl ModuleConfig for GitStatusConfig {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn format(&self) -> &str {
+        &self.format
+    }
+
+    fn style(&self) -> &str {
+        &self.style
+    }
+}
+
+impl ModuleConfig for ContextWindowConfig {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -486,13 +555,14 @@ impl Config {
         check_style("claude_model", &self.claude_model.style, &mut warnings);
         check_style("git_branch", &self.git_branch.style, &mut warnings);
         check_style("git_status", &self.git_status.style, &mut warnings);
+        check_style("context_window", &self.context_window.style, &mut warnings);
 
         // Unknown $tokens in top-level format
         for part in self.format.split_whitespace() {
             if let Some(tok) = part.strip_prefix('$') {
                 match tok {
                     "directory" | "claude_model" | "git_branch" | "git_status"
-                    | "claude_session" | "character" => {}
+                    | "context_window" | "claude_session" | "character" => {}
                     other => warnings.push(crate::messages::warn_unknown_format_token(other)),
                 }
             }

--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -54,6 +54,9 @@ pub struct Config {
     #[serde(default)]
     pub git_status: GitStatusConfig,
 
+    #[serde(default)]
+    pub context_window: ContextWindowConfig,
+
     /// Unrecognized/extra top-level tables (e.g., third-party modules)
     /// Captures unknown sections like `[my_custom_module]` without losing them.
     #[serde(flatten)]
@@ -105,6 +108,16 @@ pub struct ClaudeModelConfig {
 }
 
 impl Default for Config {
+    /// Constructs a `Config` populated with all module and global default values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = Config::default();
+    /// assert_eq!(cfg.format, default_format());
+    /// assert_eq!(cfg.command_timeout, default_command_timeout());
+    /// assert!(!cfg.debug == false); // debug defaults to false
+    /// ```
     fn default() -> Self {
         Config {
             format: default_format(),
@@ -114,6 +127,7 @@ impl Default for Config {
             claude_model: ClaudeModelConfig::default(),
             git_branch: GitBranchConfig::default(),
             git_status: GitStatusConfig::default(),
+            context_window: ContextWindowConfig::default(),
             extra_modules: toml::value::Table::new(),
         }
     }
@@ -229,6 +243,17 @@ pub struct GitStatusConfig {
 }
 
 impl Default for GitStatusConfig {
+    /// Creates a Git status configuration populated with the crate's default values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = GitStatusConfig::default();
+    /// assert_eq!(cfg.format, default_git_status_format());
+    /// assert_eq!(cfg.style, default_git_status_style());
+    /// assert_eq!(cfg.symbols, GitStatusSymbolsConfig::default());
+    /// assert_eq!(cfg.disabled, default_disabled());
+    /// ```
     fn default() -> Self {
         GitStatusConfig {
             format: default_git_status_format(),
@@ -239,7 +264,72 @@ impl Default for GitStatusConfig {
     }
 }
 
+/// Configuration for the context window module
+///
+/// Controls how the context window usage percentage is displayed.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ContextWindowConfig {
+    #[serde(default = "default_context_window_format")]
+    pub format: String,
+
+    #[serde(default = "default_context_window_style")]
+    pub style: String,
+
+    #[serde(default = "default_context_window_symbol")]
+    pub symbol: String,
+
+    /// Use dynamic color based on percentage (green/yellow/red)
+    #[serde(default = "default_context_window_use_dynamic_color")]
+    pub use_dynamic_color: bool,
+
+    /// Style for low usage (< 50%)
+    #[serde(default = "default_context_window_style_low")]
+    pub style_low: String,
+
+    /// Style for medium usage (50-79%)
+    #[serde(default = "default_context_window_style_medium")]
+    pub style_medium: String,
+
+    /// Style for high usage (≥ 80%)
+    #[serde(default = "default_context_window_style_high")]
+    pub style_high: String,
+
+    #[serde(default = "default_disabled")]
+    pub disabled: bool,
+}
+
+impl Default for ContextWindowConfig {
+    /// Creates a ContextWindowConfig populated with the crate's default values for every field.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = ContextWindowConfig::default();
+    /// // defaults provide a non-empty format string and other sane defaults
+    /// assert!(!cfg.format.is_empty());
+    /// ```
+    fn default() -> Self {
+        ContextWindowConfig {
+            format: default_context_window_format(),
+            style: default_context_window_style(),
+            symbol: default_context_window_symbol(),
+            use_dynamic_color: default_context_window_use_dynamic_color(),
+            style_low: default_context_window_style_low(),
+            style_medium: default_context_window_style_medium(),
+            style_high: default_context_window_style_high(),
+            disabled: default_disabled(),
+        }
+    }
+}
+
 // Default value functions
+/// Default top-level format string for the statusline.
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(default_format(), "$directory $claude_model".to_string());
+/// ```
 fn default_format() -> String {
     "$directory $claude_model".to_string()
 }
@@ -343,12 +433,125 @@ fn default_git_status_symbol_ahead() -> String {
 fn default_git_status_symbol_behind() -> String {
     "⇣".to_string()
 }
+/// Default symbol used to indicate a diverged Git branch in the status display.
+///
+/// Returns the symbol used when local and remote branches have diverged.
+///
+/// # Examples
+///
+/// ```
+/// let sym = default_git_status_symbol_diverged();
+/// assert_eq!(sym, "⇕");
+/// ```
 fn default_git_status_symbol_diverged() -> String {
     "⇕".to_string()
 }
 
+// Context Window module defaults
+/// Default format string for the context window module.
+///
+/// The returned string contains the `$symbol`, `$percentage`, and `$style` tokens used when rendering the context window.
+///
+/// # Examples
+///
+/// ```
+/// let fmt = default_context_window_format();
+/// assert_eq!(fmt, "[$symbol$percentage%]($style)");
+/// ```
+fn default_context_window_format() -> String {
+    "[$symbol$percentage%]($style)".to_string()
+}
+
+/// Default style token for the context window module.
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(default_context_window_style(), "bold".to_string());
+/// ```
+fn default_context_window_style() -> String {
+    "bold".to_string()
+}
+
+/// Default symbol for the context window module.
+///
+/// The returned string is "ctx ".
+///
+/// # Examples
+///
+/// ```
+/// let s = default_context_window_symbol();
+/// assert_eq!(s, "ctx ");
+/// ```
+fn default_context_window_symbol() -> String {
+    "ctx ".to_string()
+}
+
+/// Default value for ContextWindowConfig.use_dynamic_color.
+///
+/// # Examples
+///
+/// ```
+/// let enabled = default_context_window_use_dynamic_color();
+/// assert!(enabled);
+/// ```
+///
+/// # Returns
+///
+/// `true` if dynamic coloring should be enabled by default, `false` otherwise.
+fn default_context_window_use_dynamic_color() -> bool {
+    true
+}
+
+/// Default style token used for low context window usage.
+///
+/// # Examples
+///
+/// ```
+/// let s = default_context_window_style_low();
+/// assert_eq!(s, "green");
+/// ```
+fn default_context_window_style_low() -> String {
+    "green".to_string()
+}
+
+/// Default style for medium context-window usage.
+///
+/// # Examples
+///
+/// ```
+/// let s = default_context_window_style_medium();
+/// assert_eq!(s, "yellow");
+/// ```
+fn default_context_window_style_medium() -> String {
+    "yellow".to_string()
+}
+
+/// Default style used for high context window usage.
+///
+/// Returns a `String` with the value "red".
+///
+/// # Examples
+///
+/// ```
+/// let s = default_context_window_style_high();
+/// assert_eq!(s, "red");
+/// ```
+fn default_context_window_style_high() -> String {
+    "red".to_string()
+}
+
 // ModuleConfig implementations
 impl ModuleConfig for DirectoryConfig {
+    /// Provides a reference to the value as a `dyn Any` for downcasting.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = DirectoryConfig::default();
+    /// let any = cfg.as_any();
+    /// assert!(any.downcast_ref::<DirectoryConfig>().is_some());
+    /// ```
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -399,13 +602,93 @@ impl ModuleConfig for GitStatusConfig {
         &self.format
     }
 
+    /// Get the module's style string.
+    ///
+    /// # Returns
+    ///
+    /// `&str` with the module's style specification.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = DirectoryConfig::default();
+    /// assert_eq!(cfg.style(), &cfg.style);
+    /// ```
+    fn style(&self) -> &str {
+        &self.style
+    }
+}
+
+impl ModuleConfig for ContextWindowConfig {
+    /// Provides a reference to the value as a `dyn Any` for downcasting.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = DirectoryConfig::default();
+    /// let any = cfg.as_any();
+    /// assert!(any.downcast_ref::<DirectoryConfig>().is_some());
+    /// ```
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Accesses the module's format template.
+    ///
+    /// Returns the format template string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = DirectoryConfig::default();
+    /// let fmt = cfg.format();
+    /// assert!(!fmt.is_empty());
+    /// ```
+    fn format(&self) -> &str {
+        &self.format
+    }
+
+    /// Get the module's style string.
+    ///
+    /// # Returns
+    ///
+    /// `&str` with the module's style specification.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let cfg = DirectoryConfig::default();
+    /// assert_eq!(cfg.style(), &cfg.style);
+    /// ```
     fn style(&self) -> &str {
         &self.style
     }
 }
 
 impl Config {
-    /// Validate configuration values. Returns an error for clearly invalid values.
+    /// Validate configuration fields and ensure values fall within allowed ranges.
+    
+    ///
+    
+    /// Currently this enforces that the `command_timeout` value is between 50 and 600_000
+    
+    /// milliseconds (inclusive). If a value is outside this range, the function returns
+    
+    /// `CoreError::InvalidConfig` describing the invalid value.
+    
+    ///
+    
+    /// # Examples
+    
+    ///
+    
+    /// ```
+    
+    /// let cfg = Config::default();
+    
+    /// cfg.validate().unwrap();
+    
+    /// ```
     pub fn validate(&self) -> Result<(), CoreError> {
         // Milliseconds; enforce sane bounds (50ms ..= 600_000ms)
         if self.command_timeout < 50 || self.command_timeout > 600_000 {
@@ -417,9 +700,25 @@ impl Config {
         Ok(())
     }
 
-    /// Collect non-fatal warnings about style/format configuration.
-    /// Unknown style tokens or unknown variables in format strings should not
-    /// break the program, but we surface them as warnings.
+    /// Collects non-fatal warnings for style and top-level format configuration.
+    ///
+    /// Validates per-module style tokens (e.g., `bold`, `fg:#rrggbb`, `bg:bright-red`) and
+    /// checks top-level format variables prefixed with `$`. Unknown or malformed tokens are
+    /// reported as user-facing warning messages.
+    ///
+    /// # Returns
+    ///
+    /// A vector of warning strings; the vector is empty when no issues are found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_code_statusline_core::types::config::Config;
+    ///
+    /// let cfg = Config::default();
+    /// let warnings = cfg.collect_warnings();
+    /// assert!(warnings.is_empty());
+    /// ```
     pub fn collect_warnings(&self) -> Vec<String> {
         let mut warnings = Vec::new();
         fn is_named(name: &str) -> bool {
@@ -486,13 +785,14 @@ impl Config {
         check_style("claude_model", &self.claude_model.style, &mut warnings);
         check_style("git_branch", &self.git_branch.style, &mut warnings);
         check_style("git_status", &self.git_status.style, &mut warnings);
+        check_style("context_window", &self.context_window.style, &mut warnings);
 
         // Unknown $tokens in top-level format
         for part in self.format.split_whitespace() {
             if let Some(tok) = part.strip_prefix('$') {
                 match tok {
                     "directory" | "claude_model" | "git_branch" | "git_status"
-                    | "claude_session" | "character" => {}
+                    | "context_window" | "claude_session" | "character" => {}
                     other => warnings.push(crate::messages::warn_unknown_format_token(other)),
                 }
             }

--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -294,6 +294,14 @@ pub struct ContextWindowConfig {
     #[serde(default = "default_context_window_style_high")]
     pub style_high: String,
 
+    /// Threshold for medium usage level (default: 50)
+    #[serde(default = "default_context_window_threshold_medium")]
+    pub threshold_medium: u64,
+
+    /// Threshold for high usage level (default: 80)
+    #[serde(default = "default_context_window_threshold_high")]
+    pub threshold_high: u64,
+
     #[serde(default = "default_disabled")]
     pub disabled: bool,
 }
@@ -317,6 +325,8 @@ impl Default for ContextWindowConfig {
             style_low: default_context_window_style_low(),
             style_medium: default_context_window_style_medium(),
             style_high: default_context_window_style_high(),
+            threshold_medium: default_context_window_threshold_medium(),
+            threshold_high: default_context_window_threshold_high(),
             disabled: default_disabled(),
         }
     }
@@ -539,6 +549,14 @@ fn default_context_window_style_medium() -> String {
 /// ```
 fn default_context_window_style_high() -> String {
     "red".to_string()
+}
+
+fn default_context_window_threshold_medium() -> u64 {
+    50
+}
+
+fn default_context_window_threshold_high() -> u64 {
+    80
 }
 
 // ModuleConfig implementations

--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -116,7 +116,7 @@ impl Default for Config {
     /// let cfg = Config::default();
     /// assert_eq!(cfg.format, default_format());
     /// assert_eq!(cfg.command_timeout, default_command_timeout());
-    /// assert!(!cfg.debug == false); // debug defaults to false
+    /// assert_eq!(cfg.debug, false); // debug defaults to false
     /// ```
     fn default() -> Self {
         Config {

--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -261,6 +261,18 @@ pub struct ContextWindowConfig {
     #[serde(default = "default_context_window_use_dynamic_color")]
     pub use_dynamic_color: bool,
 
+    /// Style for low usage (< 50%)
+    #[serde(default = "default_context_window_style_low")]
+    pub style_low: String,
+
+    /// Style for medium usage (50-79%)
+    #[serde(default = "default_context_window_style_medium")]
+    pub style_medium: String,
+
+    /// Style for high usage (≥ 80%)
+    #[serde(default = "default_context_window_style_high")]
+    pub style_high: String,
+
     #[serde(default = "default_disabled")]
     pub disabled: bool,
 }
@@ -272,6 +284,9 @@ impl Default for ContextWindowConfig {
             style: default_context_window_style(),
             symbol: default_context_window_symbol(),
             use_dynamic_color: default_context_window_use_dynamic_color(),
+            style_low: default_context_window_style_low(),
+            style_medium: default_context_window_style_medium(),
+            style_high: default_context_window_style_high(),
             disabled: default_disabled(),
         }
     }
@@ -400,6 +415,18 @@ fn default_context_window_symbol() -> String {
 
 fn default_context_window_use_dynamic_color() -> bool {
     true
+}
+
+fn default_context_window_style_low() -> String {
+    "green".to_string()
+}
+
+fn default_context_window_style_medium() -> String {
+    "yellow".to_string()
+}
+
+fn default_context_window_style_high() -> String {
+    "red".to_string()
 }
 
 // ModuleConfig implementations

--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -112,7 +112,7 @@ impl Default for Config {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let cfg = Config::default();
     /// assert_eq!(cfg.format, default_format());
     /// assert_eq!(cfg.command_timeout, default_command_timeout());
@@ -247,7 +247,7 @@ impl Default for GitStatusConfig {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let cfg = GitStatusConfig::default();
     /// assert_eq!(cfg.format, default_git_status_format());
     /// assert_eq!(cfg.style, default_git_status_style());
@@ -311,7 +311,7 @@ impl Default for ContextWindowConfig {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let cfg = ContextWindowConfig::default();
     /// // defaults provide a non-empty format string and other sane defaults
     /// assert!(!cfg.format.is_empty());
@@ -337,7 +337,7 @@ impl Default for ContextWindowConfig {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// assert_eq!(default_format(), "$directory $claude_model".to_string());
 /// ```
 fn default_format() -> String {
@@ -449,7 +449,7 @@ fn default_git_status_symbol_behind() -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let sym = default_git_status_symbol_diverged();
 /// assert_eq!(sym, "⇕");
 /// ```
@@ -464,7 +464,7 @@ fn default_git_status_symbol_diverged() -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let fmt = default_context_window_format();
 /// assert_eq!(fmt, "[$symbol$percentage%]($style)");
 /// ```
@@ -476,7 +476,7 @@ fn default_context_window_format() -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// assert_eq!(default_context_window_style(), "bold".to_string());
 /// ```
 fn default_context_window_style() -> String {
@@ -489,7 +489,7 @@ fn default_context_window_style() -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let s = default_context_window_symbol();
 /// assert_eq!(s, "ctx ");
 /// ```
@@ -501,7 +501,7 @@ fn default_context_window_symbol() -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let enabled = default_context_window_use_dynamic_color();
 /// assert!(enabled);
 /// ```
@@ -517,7 +517,7 @@ fn default_context_window_use_dynamic_color() -> bool {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let s = default_context_window_style_low();
 /// assert_eq!(s, "green");
 /// ```
@@ -529,7 +529,7 @@ fn default_context_window_style_low() -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let s = default_context_window_style_medium();
 /// assert_eq!(s, "yellow");
 /// ```
@@ -543,7 +543,7 @@ fn default_context_window_style_medium() -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let s = default_context_window_style_high();
 /// assert_eq!(s, "red");
 /// ```
@@ -551,10 +551,31 @@ fn default_context_window_style_high() -> String {
     "red".to_string()
 }
 
+/// Default threshold percentage for medium context window usage.
+///
+/// Returns `50`, meaning percentages at or above 50 but below the high threshold
+/// will use the medium style.
+///
+/// # Examples
+///
+/// ```ignore
+/// let threshold = default_context_window_threshold_medium();
+/// assert_eq!(threshold, 50);
+/// ```
 fn default_context_window_threshold_medium() -> u64 {
     50
 }
 
+/// Default threshold percentage for high context window usage.
+///
+/// Returns `80`, meaning percentages at or above 80 will use the high style.
+///
+/// # Examples
+///
+/// ```ignore
+/// let threshold = default_context_window_threshold_high();
+/// assert_eq!(threshold, 80);
+/// ```
 fn default_context_window_threshold_high() -> u64 {
     80
 }
@@ -565,7 +586,7 @@ impl ModuleConfig for DirectoryConfig {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let cfg = DirectoryConfig::default();
     /// let any = cfg.as_any();
     /// assert!(any.downcast_ref::<DirectoryConfig>().is_some());
@@ -628,8 +649,8 @@ impl ModuleConfig for GitStatusConfig {
     ///
     /// # Examples
     ///
-    /// ```
-    /// let cfg = DirectoryConfig::default();
+    /// ```ignore
+    /// let cfg = GitStatusConfig::default();
     /// assert_eq!(cfg.style(), &cfg.style);
     /// ```
     fn style(&self) -> &str {
@@ -642,10 +663,10 @@ impl ModuleConfig for ContextWindowConfig {
     ///
     /// # Examples
     ///
-    /// ```
-    /// let cfg = DirectoryConfig::default();
+    /// ```ignore
+    /// let cfg = ContextWindowConfig::default();
     /// let any = cfg.as_any();
-    /// assert!(any.downcast_ref::<DirectoryConfig>().is_some());
+    /// assert!(any.downcast_ref::<ContextWindowConfig>().is_some());
     /// ```
     fn as_any(&self) -> &dyn Any {
         self
@@ -657,8 +678,8 @@ impl ModuleConfig for ContextWindowConfig {
     ///
     /// # Examples
     ///
-    /// ```
-    /// let cfg = DirectoryConfig::default();
+    /// ```ignore
+    /// let cfg = ContextWindowConfig::default();
     /// let fmt = cfg.format();
     /// assert!(!fmt.is_empty());
     /// ```
@@ -674,8 +695,8 @@ impl ModuleConfig for ContextWindowConfig {
     ///
     /// # Examples
     ///
-    /// ```
-    /// let cfg = DirectoryConfig::default();
+    /// ```ignore
+    /// let cfg = ContextWindowConfig::default();
     /// assert_eq!(cfg.style(), &cfg.style);
     /// ```
     fn style(&self) -> &str {
@@ -697,15 +718,15 @@ impl Config {
     ///
     
     /// # Examples
-    
+
     ///
-    
-    /// ```
-    
+
+    /// ```ignore
+
     /// let cfg = Config::default();
-    
+
     /// cfg.validate().unwrap();
-    
+
     /// ```
     pub fn validate(&self) -> Result<(), CoreError> {
         // Milliseconds; enforce sane bounds (50ms ..= 600_000ms)

--- a/crates/claude-code-statusline-core/src/types/context.rs
+++ b/crates/claude-code-statusline-core/src/types/context.rs
@@ -140,7 +140,23 @@ mod tests {
     #[cfg(feature = "git")]
     use git2::Repository as GitRepository;
 
-    /// Helper to create test ClaudeInput
+    /// Construct a ClaudeInput populated with sensible defaults for use in tests.
+    ///
+    /// The returned `ClaudeInput` has the provided current working directory, model
+    /// information, and an optional workspace mapping; other fields are set to
+    /// stable test-friendly defaults.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let input = create_claude_input("/repo", "x1", None);
+    /// assert_eq!(input.cwd, "/repo");
+    /// assert_eq!(input.model.display_name, "x1");
+    ///
+    /// let ws = create_claude_input("/repo/sub", "x1", Some(("/repo/sub", "/repo")));
+    /// assert_eq!(ws.workspace.as_ref().unwrap().current_dir, "/repo/sub");
+    /// assert_eq!(ws.workspace.as_ref().unwrap().project_dir.as_deref(), Some("/repo"));
+    /// ```
     fn create_claude_input(cwd: &str, model: &str, workspace: Option<(&str, &str)>) -> ClaudeInput {
         ClaudeInput {
             hook_event_name: None,
@@ -157,6 +173,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         }
     }
 

--- a/crates/claude-code-statusline-core/src/types/context.rs
+++ b/crates/claude-code-statusline-core/src/types/context.rs
@@ -157,6 +157,7 @@ mod tests {
             }),
             version: Some("1.0.0".to_string()),
             output_style: None,
+            context_window: None,
         }
     }
 

--- a/crates/test-support/src/builders.rs
+++ b/crates/test-support/src/builders.rs
@@ -75,6 +75,22 @@ impl ClaudeInputBuilder {
         self
     }
 
+    /// Builds a `ClaudeInput` from the builder's current fields.
+    ///
+    /// The returned `ClaudeInput` will contain the values configured on this builder; its
+    /// `context_window` field is set to `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let input = ClaudeInputBuilder::new()
+    ///     .with_cwd("/tmp")
+    ///     .with_session_id("sess-1")
+    ///     .build();
+    /// assert_eq!(input.cwd, "/tmp");
+    /// assert_eq!(input.session_id, "sess-1");
+    /// assert_eq!(input.context_window, None);
+    /// ```
     pub fn build(self) -> ClaudeInput {
         ClaudeInput {
             hook_event_name: self.hook_event_name,
@@ -85,6 +101,7 @@ impl ClaudeInputBuilder {
             workspace: self.workspace,
             version: self.version,
             output_style: self.output_style,
+            context_window: None,
         }
     }
 }

--- a/crates/test-support/src/builders.rs
+++ b/crates/test-support/src/builders.rs
@@ -82,7 +82,7 @@ impl ClaudeInputBuilder {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let input = ClaudeInputBuilder::new()
     ///     .with_cwd("/tmp")
     ///     .with_session_id("sess-1")

--- a/crates/test-support/src/builders.rs
+++ b/crates/test-support/src/builders.rs
@@ -85,6 +85,7 @@ impl ClaudeInputBuilder {
             workspace: self.workspace,
             version: self.version,
             output_style: self.output_style,
+            context_window: None,
         }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ Tokens: `$path`
 
 例:
 
-```
+```text
 # 例1: repo 直下
 truncate_to_repo = true
 truncation_length = 3
@@ -125,6 +125,51 @@ Tokens: `$all_status`, `$ahead_behind`
  - ライブラリ利用時（`claude-code-statusline-core` を直接依存する場合）にこのモジュールを使うには
    crate の feature `git` を有効にしてください。CLI バイナリは既定で有効です。
 
+### Module: `context_window`
+
+```toml
+[context_window]
+format = "[$symbol$percentage%]($style)"
+symbol = "ctx "
+style = "bold"
+use_dynamic_color = true
+style_low = "green"
+style_medium = "yellow"
+style_high = "red"
+disabled = false
+```
+
+Tokens: `$percentage`, `$symbol`
+
+振る舞い:
+- コンテキストウィンドウの使用率をパーセンテージで表示します。
+- `use_dynamic_color = true` の場合、使用率に応じて自動的にスタイルを変更します:
+  - `style_low`: 50%未満の使用率（既定: "green"）
+  - `style_medium`: 50-79%の使用率（既定: "yellow"）
+  - `style_high`: 80%以上の使用率（既定: "red"）
+- `use_dynamic_color = false` の場合、固定の `style` を使用します。
+- 計算には `current_usage` データを使用し、キャッシュされたトークン（system prompt、tools、agents）を含む実際の使用量を正確に反映します。
+
+例:
+
+```toml
+# カスタマイズされた閾値スタイル
+[context_window]
+symbol = "🔵 "
+use_dynamic_color = true
+style_low = "bold green"
+style_medium = "bold yellow"
+style_high = "bold underline red"
+```
+
+```toml
+# 固定スタイル（動的カラーなし）
+[context_window]
+symbol = "ctx "
+use_dynamic_color = false
+style = "bold blue"
+```
+
 ### ANSI スタイル指定
 
 `[$text]($style)` 構文で装飾を付けられます。`($style)` が `$style` の場合は、そのモジュール設定の `style` 値を適用します。
@@ -145,7 +190,7 @@ Tokens: `$all_status`, `$ahead_behind`
 
 例:
 
-```
+```text
 style = "bold fg:green bg:black"        # 太字 + 前景緑 + 背景黒
 style = "bright-yellow bg:bright-blue"    # 明るい黄(前景) + 明るい青(背景)
 style = "fg:196 bg:238"                  # 8bit インデックス色


### PR DESCRIPTION
# Add context window usage percentage display module

## Summary

This PR adds a new `context_window` module that displays real-time context window usage as a percentage, helping users monitor their token consumption during Claude Code sessions.

## Features

### Context Window Monitoring
- **Real-time percentage display** of context window usage
- **Accurate calculation** including all token types (regular, cache creation, cache read)
- **Configurable threshold-based color coding**:
  - Green: < 50% usage
  - Yellow: 50-79% usage
  - Red: ≥ 80% usage

### Customization Options
- **Dynamic color thresholds**: Fully customizable styles for each usage tier
- **Custom symbols**: Configure display symbol (default: "ctx ")
- **Static styling**: Option to use fixed style instead of dynamic colors
- **Full ANSI support**: Bold, italic, underline, 256-color, RGB colors

## Configuration Examples

### Basic Usage (default)
```toml
format = "$directory $claude_model $context_window"

[context_window]
symbol = "ctx "
use_dynamic_color = true
```

### Custom Threshold Styles
```toml
[context_window]
symbol = "🔵 "
use_dynamic_color = true
style_low = "bold green"
style_medium = "bold yellow"
style_high = "bold underline red"
```

### Fixed Style (no dynamic colors)
```toml
[context_window]
symbol = "ctx "
use_dynamic_color = false
style = "bold blue"
```

## Example Output

```text
/project 🌿 main Sonnet4.5 🔵 47%
```

The percentage automatically changes color from green → yellow → red as context usage increases.

## Technical Details

### Accurate Token Calculation
The module uses the `current_usage` breakdown from Claude Code's JSON input to calculate accurate percentages:

```rust
let total_tokens = usage.input_tokens
    + usage.cache_creation_input_tokens
    + usage.cache_read_input_tokens;
```

This ensures the displayed percentage matches the actual context usage shown by the `/context` command, including:
- Regular input tokens
- Cached system prompts
- Cached tools and agents
- Cached memory files

Previously, using only `total_input_tokens` showed 3% when actual usage was 47% because it excluded ~94k cached tokens.

### Implementation
- Follows existing module patterns and conventions
- Comprehensive test coverage including custom threshold tests
- Graceful fallback to `total_input_tokens` if `current_usage` unavailable
- Zero performance impact (percentage calculation is O(1))

## Testing

All tests pass including new custom threshold style tests:
```bash
cargo test --workspace
```

Benchmark performance remains under 50ms threshold:
```bash
make bench-check
```

## Documentation

- ✅ README.md updated with module listing and examples
- ✅ docs/configuration.md updated with Japanese documentation
- ✅ Inline code documentation and comments
- ✅ Configuration examples for common use cases

## Commits

1. `feat: add context window usage percentage display` - Initial implementation
2. `fix: include cached tokens in context window percentage calculation` - Accuracy fix + configurable thresholds
3. `docs: add context_window module documentation` - Complete documentation

## Checklist

- [x] Code follows existing patterns and style
- [x] Comprehensive tests added
- [x] Documentation updated (English + Japanese)
- [x] All tests passing
- [x] Benchmarks within performance limits
- [x] No breaking changes
- [x] Feature is opt-in (add `$context_window` to format string)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Context Window module showing context usage as a percentage with colorized output; default status line includes a context_window token.

* **Configuration**
  * New context_window config block (format, symbol "ctx ", dynamic-color toggle, low/medium/high styles and thresholds); integrated into defaults and validation.

* **Documentation**
  * README and docs updated with tokens ($percentage, $symbol), examples and usage guidance.

* **Tests**
  * Unit tests and test helpers updated to cover the new module and configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->